### PR TITLE
Add users, user authentication

### DIFF
--- a/lib/elixir_job_board/factory.ex
+++ b/lib/elixir_job_board/factory.ex
@@ -1,0 +1,12 @@
+defmodule ElixirJobBoard.Factory do
+  use ExMachina.Ecto, repo: ElixirJobBoard.Repo
+
+  def job_factory do
+    %ElixirJobBoard.Job{title: "Something Important",
+      description: "a new job",
+       poster_email: "poster.email@example.com",
+       contact_email: "contact.email@example.com",
+       location: "Somewhere",
+       published_at: Ecto.DateTime.utc}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -37,6 +37,7 @@ defmodule ElixirJobBoard.Mixfile do
      {:phoenix_html, "~> 2.6"},
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.11"},
+     {:comeonin, "~> 1.0"},
      {:cowboy, "~> 1.0"}]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule ElixirJobBoard.Mixfile do
      {:gettext, "~> 0.11"},
      {:cowboy, "~> 1.0"},
      {:ex_machina, "~> 1.0.2"},
-     {:comeonin, "~> 1.0"}]
+     {:comeonin, "~> 2.5"}]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,8 @@ defmodule ElixirJobBoard.Mixfile do
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.11"},
      {:cowboy, "~> 1.0"},
-     {:ex_machina, "~> 1.0.2"}]
+     {:ex_machina, "~> 1.0.2"},
+     {:comeonin, "~> 1.0"}]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,8 @@ defmodule ElixirJobBoard.Mixfile do
      {:phoenix_html, "~> 2.6"},
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.11"},
-     {:cowboy, "~> 1.0"}]
+     {:cowboy, "~> 1.0"},
+     {:ex_machina, "~> 1.0.2"}]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule ElixirJobBoard.Mixfile do
      {:phoenix_html, "~> 2.6"},
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.11"},
-     {:comeonin, "~> 1.0"},
+     {:comeonin, "~> 2.5"},
      {:cowboy, "~> 1.0"}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
+%{"comeonin": {:hex, :comeonin, "1.6.0", "65d3217bf171feb2600ac639089d1316c5438407a30dfbe9f465d75500db2171", [:mix, :make, :make], [{:comeonin_i18n, "~> 0.1", [hex: :comeonin_i18n, optional: true]}]},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "db_connection": {:hex, :db_connection, "1.0.0-rc.5", "1d9ab6e01387bdf2de7a16c56866971f7c2f75aea7c69cae2a0346e4b537ae0d", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}]},

--- a/mix.lock
+++ b/mix.lock
@@ -4,6 +4,7 @@
   "db_connection": {:hex, :db_connection, "1.0.0-rc.5", "1d9ab6e01387bdf2de7a16c56866971f7c2f75aea7c69cae2a0346e4b537ae0d", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
   "ecto": {:hex, :ecto, "2.0.5", "7f4c79ac41ffba1a4c032b69d7045489f0069c256de606523c65d9f8188e502d", [:mix], [{:db_connection, "~> 1.0-rc.4", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.1.2 or ~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.7.7", [hex: :mariaex, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.12.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}]},
+  "ex_machina": {:hex, :ex_machina, "1.0.2", "1cc49e1a09e3f7ab2ecb630c17f14c2872dc4ec145d6d05a9c3621936a63e34f", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: true]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"comeonin": {:hex, :comeonin, "1.6.0", "65d3217bf171feb2600ac639089d1316c5438407a30dfbe9f465d75500db2171", [:mix, :make, :make], [{:comeonin_i18n, "~> 0.1", [hex: :comeonin_i18n, optional: true]}]},
+%{"comeonin": {:hex, :comeonin, "2.5.3", "ccd70ebf465eaf4e11fc5a13fd0f5be2538b6b4975d4f7a13d571670b31da060", [:mix, :make, :make], []},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},

--- a/priv/repo/migrations/20160924182056_create_user.exs
+++ b/priv/repo/migrations/20160924182056_create_user.exs
@@ -1,0 +1,14 @@
+defmodule ElixirJobBoard.Repo.Migrations.CreateUser do
+  use Ecto.Migration
+
+  def change do
+    create table(:users) do
+      add :email, :string
+      add :crypted_password, :string
+
+      timestamps()
+    end
+    create unique_index(:users, [:email])
+
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,25 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+# Empty the users table
+ElixirJobBoard.Repo.delete_all(ElixirJobBoard.User)
+
+default_password = "password"
+
+pg_changeset = ElixirJobBoard.User.changeset(
+  %ElixirJobBoard.User{},
+  %{ "email" => "pg13@pacers.com", "password" => "password" }
+)
+myles_changeset = ElixirJobBoard.User.changeset(
+  %ElixirJobBoard.User{},
+  %{ "email" => "myles@pacers.com", "password" => "password" }
+)
+zeisloft_changeset = ElixirJobBoard.User.changeset(
+  %ElixirJobBoard.User{},
+  %{ "email" => "nick.zeisloft.iu@pacers.com", "password" => "password" }
+)
+
+ElixirJobBoard.Registration.create(pg_changeset, ElixirJobBoard.Repo)
+ElixirJobBoard.Registration.create(myles_changeset, ElixirJobBoard.Repo)
+ElixirJobBoard.Registration.create(zeisloft_changeset, ElixirJobBoard.Repo)

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -17,15 +17,15 @@ default_password = "password"
 
 pg_changeset = ElixirJobBoard.User.changeset(
   %ElixirJobBoard.User{},
-  %{ "email" => "pg13@pacers.com", "password" => "password" }
+  %{ "email" => "pg13@pacers.com", "password" => default_password}
 )
 myles_changeset = ElixirJobBoard.User.changeset(
   %ElixirJobBoard.User{},
-  %{ "email" => "myles@pacers.com", "password" => "password" }
+  %{ "email" => "myles@pacers.com", "password" => default_password }
 )
 zeisloft_changeset = ElixirJobBoard.User.changeset(
   %ElixirJobBoard.User{},
-  %{ "email" => "nick.zeisloft.iu@pacers.com", "password" => "password" }
+  %{ "email" => "nick.zeisloft.iu@pacers.com", "password" => default_password }
 )
 
 ElixirJobBoard.Registration.create(pg_changeset, ElixirJobBoard.Repo)

--- a/test/controllers/posts_controller_test.exs
+++ b/test/controllers/posts_controller_test.exs
@@ -1,0 +1,73 @@
+defmodule ElixirJobBoard.PostsControllerTest do
+  use ElixirJobBoard.ConnCase
+  alias ElixirJobBoard.Job
+  import ElixirJobBoard.Factory
+  require IEx
+
+  test "GET /posts", %{conn: conn} do
+    conn = get conn, "/posts"
+    assert html_response(conn, 200)
+  end
+
+  test "GET /posts/new", %{conn: conn} do
+    conn = get conn, "/posts/new"
+    assert html_response(conn, 200)
+  end
+
+  test "GET /posts/:id", %{conn: conn} do
+    job = insert(:job)
+    conn = get conn, "/posts/#{job.id}"
+    assert html_response(conn, 200)
+  end
+
+  test "GET /posts/:id/edit", %{conn: conn} do
+    job = insert(:job)
+    conn = get conn, "/posts/#{job.id}/edit"
+    assert html_response(conn, 200)
+  end
+
+  test "successful POST /posts", %{conn: conn} do
+    jobs_count = length(Repo.all(Job))
+    job_params = %{"title"        => "Something Important",
+                  "description"   => "a new job",
+                  "poster_email"  => "poster.email@example.com",
+                  "contact_email" => "contact.email@example.com",
+                  "location"      => "Somewhere",
+                  "published_at"  => Ecto.DateTime.utc}
+    conn = post conn, "/posts", %{"job" => job_params}
+    assert get_flash(conn, :info) == "Job created successfully."
+    assert redirected_to(conn) =~ "/posts"
+    assert (length(Repo.all(Job))) > jobs_count
+    assert_in_delta(jobs_count, length(Repo.all(Job)), 2)
+  end
+
+  test "unsuccessful POST /posts", %{conn: conn} do
+    jobs_count = length(Repo.all(Job))
+    job_params = %{"title"        => "Something Important",
+                  "poster_email"  => "poster.email@example.com",
+                  "contact_email" => "contact.email@example.com",
+                  "location"      => "Somewhere",
+                  "published_at"  => Ecto.DateTime.utc}
+    refute Job.changeset(%Job{}, job_params).valid?
+    conn = post conn, "/posts", %{"job" => job_params}
+    assert html_response(conn, 200)
+    assert jobs_count == length(Repo.all(Job))
+    assert_in_delta(jobs_count, length(Repo.all(Job)), 1)
+  end
+
+  test "successful PATCH /posts/:id", %{conn: conn} do
+    job = insert(:job)
+    job_params = %{"title" => "Something Important"}
+    conn = patch conn, "/posts/#{job.id}", %{"id" => job.id, "job" => job_params}
+    assert get_flash(conn, :info) == "Job successfully updated."
+    assert redirected_to(conn) =~ "/posts/#{job.id}"
+  end
+
+  test "unsuccessful PATCH /posts/:id", %{conn: conn} do
+    job = insert(:job)
+    job_params = %{"title" => nil}
+    conn = patch conn, "/posts/#{job.id}", %{"id" => job.id, "job" => job_params}
+    assert html_response(conn, 200)
+    refute Job.changeset(job, job_params).valid?
+  end
+end

--- a/test/models/registration_test.exs
+++ b/test/models/registration_test.exs
@@ -1,0 +1,21 @@
+defmodule ElixirJobBoard.RegistrationTest do
+  use ElixirJobBoard.ModelCase
+
+  alias ElixirJobBoard.Registration
+  alias ElixirJobBoard.User
+
+  @valid_attrs %{ password: "some content", email: "some_content@some_content.com" }
+  @invalid_attrs %{ password: "some content" }
+
+  test "creates a user when given valid attributes" do
+    changeset = User.changeset(%User{}, @valid_attrs)
+    result = Registration.create(changeset, ElixirJobBoard.Repo)
+    assert elem(result, 0) == :ok
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = User.changeset(%User{}, @invalid_attrs)
+    result = Registration.create(changeset, ElixirJobBoard.Repo)
+    refute elem(result, 0) == :ok
+  end
+end

--- a/test/models/registration_test.exs
+++ b/test/models/registration_test.exs
@@ -1,0 +1,21 @@
+defmodule ElixirJobBoard.RegistrationTest do
+  use ElixirJobBoard.ModelCase
+
+  alias ElixirJobBoard.Registration
+  alias ElixirJobBoard.User
+
+  @valid_attrs %{ password: "some content", email: "some_content@some_content.com" }
+  @invalid_attrs %{ password: "some content" }
+
+  test "creates a user when given valid attributes" do
+    changeset = User.changeset(%User{}, @valid_attrs)
+    result = Registration.create(changeset, ElixirJobBoard.Repo) 
+    assert elem(result, 0) == :ok
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = User.changeset(%User{}, @invalid_attrs)
+    result = Registration.create(changeset, ElixirJobBoard.Repo) 
+    refute elem(result, 0) == :ok
+  end
+end

--- a/test/models/registration_test.exs
+++ b/test/models/registration_test.exs
@@ -9,13 +9,15 @@ defmodule ElixirJobBoard.RegistrationTest do
 
   test "creates a user when given valid attributes" do
     changeset = User.changeset(%User{}, @valid_attrs)
-    result = Registration.create(changeset, ElixirJobBoard.Repo)
-    assert elem(result, 0) == :ok
+    assert ElixirJobBoard.Repo.get_by(User, email: "some_content@some_content.com") == nil
+    Registration.create(changeset, ElixirJobBoard.Repo)
+    refute ElixirJobBoard.Repo.get_by(User, email: "some_content@some_content.com") == nil
   end
 
   test "changeset with invalid attributes" do
     changeset = User.changeset(%User{}, @invalid_attrs)
-    result = Registration.create(changeset, ElixirJobBoard.Repo)
-    refute elem(result, 0) == :ok
+    assert ElixirJobBoard.Repo.get_by(User, email: "some_content@some_content.com") == nil
+    Registration.create(changeset, ElixirJobBoard.Repo)
+    assert ElixirJobBoard.Repo.get_by(User, email: "some_content@some_content.com") == nil
   end
 end

--- a/test/models/registration_test.exs
+++ b/test/models/registration_test.exs
@@ -9,13 +9,15 @@ defmodule ElixirJobBoard.RegistrationTest do
 
   test "creates a user when given valid attributes" do
     changeset = User.changeset(%User{}, @valid_attrs)
-    result = Registration.create(changeset, ElixirJobBoard.Repo) 
-    assert elem(result, 0) == :ok
+    assert ElixirJobBoard.Repo.get_by(User, email: "some_content@some_content.com") == nil
+    Registration.create(changeset, ElixirJobBoard.Repo)
+    refute ElixirJobBoard.Repo.get_by(User, email: "some_content@some_content.com") == nil
   end
 
   test "changeset with invalid attributes" do
     changeset = User.changeset(%User{}, @invalid_attrs)
-    result = Registration.create(changeset, ElixirJobBoard.Repo) 
-    refute elem(result, 0) == :ok
+    assert ElixirJobBoard.Repo.get_by(User, email: "some_content@some_content.com") == nil
+    Registration.create(changeset, ElixirJobBoard.Repo)
+    assert ElixirJobBoard.Repo.get_by(User, email: "some_content@some_content.com") == nil
   end
 end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -1,0 +1,18 @@
+defmodule ElixirJobBoard.UserTest do
+  use ElixirJobBoard.ModelCase
+
+  alias ElixirJobBoard.User
+
+  @valid_attrs %{crypted_password: "some content", email: "some content"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = User.changeset(%User{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = User.changeset(%User{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -3,7 +3,7 @@ defmodule ElixirJobBoard.UserTest do
 
   alias ElixirJobBoard.User
 
-  @valid_attrs %{crypted_password: "some content", email: "some content"}
+  @valid_attrs %{password: "some content", email: "some_content@some_content.com"}
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
+{:ok, _} = Application.ensure_all_started(:ex_machina)
 ExUnit.start
 
 Ecto.Adapters.SQL.Sandbox.mode(ElixirJobBoard.Repo, :manual)
-

--- a/web/controllers/posts_controller.ex
+++ b/web/controllers/posts_controller.ex
@@ -1,5 +1,6 @@
 defmodule ElixirJobBoard.PostsController do
   use ElixirJobBoard.Web, :controller
+  require IEx
 
   alias ElixirJobBoard.Job
 
@@ -27,7 +28,7 @@ defmodule ElixirJobBoard.PostsController do
         |> put_flash(:info, "Job created successfully.")
         |> redirect(to: posts_path(conn, :index))
       {:error, changeset} ->
-        render("new.html", changeset: changeset)
+        render(conn, "new.html", changeset: changeset)
     end
   end
 
@@ -47,7 +48,7 @@ defmodule ElixirJobBoard.PostsController do
         |> put_flash(:info, "Job successfully updated.")
         |> redirect(to: posts_path(conn, :show, id))
       {:error, changeset} ->
-        render("edit.html", id: id, changeset: changeset)
+        render(conn, "edit.html", id: id, changeset: changeset, job: job)
     end
   end
 end

--- a/web/controllers/session_controller.ex
+++ b/web/controllers/session_controller.ex
@@ -1,0 +1,28 @@
+defmodule ElixirJobBoard.SessionController do
+  use ElixirJobBoard.Web, :controller
+
+  def new(conn, _params) do
+    render(conn, "new.html")
+  end
+
+  def create(conn, %{"session" => session_params}) do
+    case ElixirJobBoard.Session.login(session_params, ElixirJobBoard.Repo) do
+      {:ok, user} ->
+        conn
+        |> put_session(:current_user, user.id)
+        |> put_flash(:info, "Logged in")
+        |> redirect(to: "/")
+      :error ->
+        conn
+        |> put_flash(:info, "Wrong email or password")
+        |> render("new.html")
+    end
+  end
+
+  def delete(conn, _) do
+    conn
+    |> delete_session(:current_user)
+    |> put_flash(:info, "Logged out")
+    |> redirect(to: "/")
+  end
+end

--- a/web/models/registration.ex
+++ b/web/models/registration.ex
@@ -1,0 +1,13 @@
+defmodule ElixirJobBoard.Registration do
+  import Ecto.Changeset, only: [put_change: 3]
+
+  def create(changeset, repo) do
+    changeset
+    |> put_change(:crypted_password, hashed_password(changeset.params["password"]))
+    |> repo.insert()
+  end
+
+  defp hashed_password(password) do
+    Comeonin.Bcrypt.hashpwsalt(password)
+  end
+end

--- a/web/models/session.ex
+++ b/web/models/session.ex
@@ -1,0 +1,25 @@
+defmodule ElixirJobBoard.Session do
+  alias ElixirJobBoard.User
+
+  def login(params, repo) do
+    user = repo.get_by(User, email: String.downcase(params["email"]))
+    case authenticate(user, params["password"]) do
+      true -> {:ok, user}
+      _    -> :error
+    end
+  end
+
+  defp authenticate(user, password) do
+    case user do
+      nil -> false
+      _   -> Comeonin.Bcrypt.checkpw(password, user.crypted_password)
+    end
+  end
+
+  def current_user(conn) do
+    id = Plug.Conn.get_session(conn, :current_user)
+    if id, do: ElixirJobBoard.Repo.get(User, id)
+  end
+
+  def logged_in?(conn), do: !!current_user(conn)
+end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -1,0 +1,22 @@
+defmodule ElixirJobBoard.User do
+  use ElixirJobBoard.Web, :model
+
+  schema "users" do
+    field :email, :string
+    field :crypted_password, :string
+    field :password, :string, virtual: true
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:email, :password])
+    |> validate_required([:email, :password])
+    |> unique_constraint(:email)
+    |> validate_format(:email, ~r/@/)
+    |> validate_length(:password, min: 5)
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -17,6 +17,11 @@ defmodule ElixirJobBoard.Router do
     pipe_through :browser # Use the default browser stack
 
     get "/", PageController, :index
+
+    get "/login", SessionController, :new
+    post "/login", SessionController, :create
+    delete "/logout", SessionController, :delete
+
     resources "/posts", PostsController
   end
 

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -16,7 +16,12 @@
       <header class="header">
         <nav role="navigation">
           <ul class="nav nav-pills pull-right">
-            <li><a href="http://www.phoenixframework.org/docs">Get Started</a></li>
+            <%= if logged_in?(@conn) do %>
+              <li><%= current_user(@conn).email %></li>
+              <li><%= link "Logout", to: session_path(@conn, :delete), method: :delete %></li>
+            <% else %>
+              <li><%= link "Login", to: "/login" %></li>
+            <% end %>
           </ul>
         </nav>
         <span class="logo"></span>

--- a/web/templates/session/new.html.eex
+++ b/web/templates/session/new.html.eex
@@ -1,0 +1,17 @@
+<h2>Login</h2>
+
+<%= form_for @conn, session_path(@conn, :create), [as: :session], fn f -> %>
+  <div class="form-group">
+    <label>Email</label>
+    <%= text_input f, :email, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <label>Password</label>
+    <%= password_input f, :password, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= submit "Login", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/web/views/session_view.ex
+++ b/web/views/session_view.ex
@@ -1,0 +1,3 @@
+defmodule ElixirJobBoard.SessionView do
+  use ElixirJobBoard.Web, :view
+end

--- a/web/web.ex
+++ b/web/web.ex
@@ -52,6 +52,7 @@ defmodule ElixirJobBoard.Web do
       import ElixirJobBoard.Router.Helpers
       import ElixirJobBoard.ErrorHelpers
       import ElixirJobBoard.Gettext
+      import ElixirJobBoard.Session, only: [current_user: 1, logged_in?: 1]
     end
   end
 


### PR DESCRIPTION
I used [this](http://nithinbekal.com/posts/phoenix-authentication/) as a reference. Its first comment was from @stevegrossi, which I thought was pretty grand.

I left off registration, as I don't want users to register for the site. The end goal is to have admins that we create manually, and job posters who can only "login" via the token-ized URLs in their inboxes.

I was able to load up a console (`iex -S phoenix.server`) and run the following to create a user:

``` elixir
changeset = ElixirJobBoard.User.changeset(%ElixirJobBoard.User{}, %{ "email" => "miles@mileszs.com", "password" => "password")

ElixirJobBoard.Registration.create(changeset, ElixirJobBoard.Repo)
```

Then, I could log in using those credentials. Whee!

PS - I know, we still haven't written any tests. In this experimental phase, I'm okay with that. We should totally write tests before this thing goes live, though. :-) We should probably write tests before we start polishing / writing complicated features. I've already looked at [a code coverage tool](http://tech.findmypast.com/elixir-maintainability/#excoveralls) and [a code linter](http://tech.findmypast.com/elixir-maintainability/#excoveralls). 
