### PR TITLE
Posts Controller Tests

### DIFF
--- a/lib/elixir_job_board/factory.ex
+++ b/lib/elixir_job_board/factory.ex
@@ -1,0 +1,12 @@
+defmodule ElixirJobBoard.Factory do
+  use ExMachina.Ecto, repo: ElixirJobBoard.Repo
+
+  def job_factory do
+    %ElixirJobBoard.Job{title: "Something Important",
+      description: "a new job",
+       poster_email: "poster.email@example.com",
+       contact_email: "contact.email@example.com",
+       location: "Somewhere",
+       published_at: Ecto.DateTime.utc}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,8 @@ defmodule ElixirJobBoard.Mixfile do
      {:phoenix_html, "~> 2.6"},
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.11"},
-     {:cowboy, "~> 1.0"}]
+     {:cowboy, "~> 1.0"},
+     {:ex_machina, "~> 1.0.2"}]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/mix.lock
+++ b/mix.lock
@@ -4,6 +4,7 @@
   "db_connection": {:hex, :db_connection, "1.0.0-rc.5", "1d9ab6e01387bdf2de7a16c56866971f7c2f75aea7c69cae2a0346e4b537ae0d", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
   "ecto": {:hex, :ecto, "2.0.5", "7f4c79ac41ffba1a4c032b69d7045489f0069c256de606523c65d9f8188e502d", [:mix], [{:db_connection, "~> 1.0-rc.4", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.1.2 or ~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.7.7", [hex: :mariaex, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.12.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}]},
+  "ex_machina": {:hex, :ex_machina, "1.0.2", "1cc49e1a09e3f7ab2ecb630c17f14c2872dc4ec145d6d05a9c3621936a63e34f", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: true]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},

--- a/test/controllers/posts_controller_test.exs
+++ b/test/controllers/posts_controller_test.exs
@@ -1,0 +1,73 @@
+defmodule ElixirJobBoard.PostsControllerTest do
+  use ElixirJobBoard.ConnCase
+  alias ElixirJobBoard.Job
+  import ElixirJobBoard.Factory
+  require IEx
+
+  test "GET /posts", %{conn: conn} do
+    conn = get conn, "/posts"
+    assert html_response(conn, 200)
+  end
+
+  test "GET /posts/new", %{conn: conn} do
+    conn = get conn, "/posts/new"
+    assert html_response(conn, 200)
+  end
+
+  test "GET /posts/:id", %{conn: conn} do
+    job = insert(:job)
+    conn = get conn, "/posts/#{job.id}"
+    assert html_response(conn, 200)
+  end
+
+  test "GET /posts/:id/edit", %{conn: conn} do
+    job = insert(:job)
+    conn = get conn, "/posts/#{job.id}/edit"
+    assert html_response(conn, 200)
+  end
+
+  test "successful POST /posts", %{conn: conn} do
+    jobs_count = length(Repo.all(Job))
+    job_params = %{"title"        => "Something Important",
+                  "description"   => "a new job",
+                  "poster_email"  => "poster.email@example.com",
+                  "contact_email" => "contact.email@example.com",
+                  "location"      => "Somewhere",
+                  "published_at"  => Ecto.DateTime.utc}
+    conn = post conn, "/posts", %{"job" => job_params}
+    assert get_flash(conn, :info) == "Job created successfully."
+    assert redirected_to(conn) =~ "/posts"
+    assert (length(Repo.all(Job))) > jobs_count
+    assert_in_delta(jobs_count, length(Repo.all(Job)), 2)
+  end
+
+  test "unsuccessful POST /posts", %{conn: conn} do
+    jobs_count = length(Repo.all(Job))
+    job_params = %{"title"        => "Something Important",
+                  "poster_email"  => "poster.email@example.com",
+                  "contact_email" => "contact.email@example.com",
+                  "location"      => "Somewhere",
+                  "published_at"  => Ecto.DateTime.utc}
+    refute Job.changeset(%Job{}, job_params).valid?
+    conn = post conn, "/posts", %{"job" => job_params}
+    assert html_response(conn, 200)
+    assert jobs_count == length(Repo.all(Job))
+    assert_in_delta(jobs_count, length(Repo.all(Job)), 1)
+  end
+
+  test "successful PATCH /posts/:id", %{conn: conn} do
+    job = insert(:job)
+    job_params = %{"title" => "Something Important"}
+    conn = patch conn, "/posts/#{job.id}", %{"id" => job.id, "job" => job_params}
+    assert get_flash(conn, :info) == "Job successfully updated."
+    assert redirected_to(conn) =~ "/posts/#{job.id}"
+  end
+
+  test "unsuccessful PATCH /posts/:id", %{conn: conn} do
+    job = insert(:job)
+    job_params = %{"title" => nil}
+    conn = patch conn, "/posts/#{job.id}", %{"id" => job.id, "job" => job_params}
+    assert html_response(conn, 200)
+    refute Job.changeset(job, job_params).valid?
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
+{:ok, _} = Application.ensure_all_started(:ex_machina)
 ExUnit.start
 
 Ecto.Adapters.SQL.Sandbox.mode(ElixirJobBoard.Repo, :manual)
-

--- a/web/controllers/posts_controller.ex
+++ b/web/controllers/posts_controller.ex
@@ -1,5 +1,6 @@
 defmodule ElixirJobBoard.PostsController do
   use ElixirJobBoard.Web, :controller
+  require IEx
 
   alias ElixirJobBoard.Job
 
@@ -27,7 +28,7 @@ defmodule ElixirJobBoard.PostsController do
         |> put_flash(:info, "Job created successfully.")
         |> redirect(to: posts_path(conn, :index))
       {:error, changeset} ->
-        render("new.html", changeset: changeset)
+        render(conn, "new.html", changeset: changeset)
     end
   end
 
@@ -47,7 +48,7 @@ defmodule ElixirJobBoard.PostsController do
         |> put_flash(:info, "Job successfully updated.")
         |> redirect(to: posts_path(conn, :show, id))
       {:error, changeset} ->
-        render("edit.html", id: id, changeset: changeset)
+        render(conn, "edit.html", id: id, changeset: changeset, job: job)
     end
   end
 end


### PR DESCRIPTION
Adds tests for the Posts controller. Also adds new mix called [ExMachina](https://github.com/thoughtbot/ex_machina) that allows you to create factories for your Ecto Models because Phoenix does not have fixtures. Fixes an unsuccessful create and update actions because they were not working.
