### PR TITLE
Add an admin section, with auth requiring an admin

### DIFF
--- a/lib/elixir_job_board/factory.ex
+++ b/lib/elixir_job_board/factory.ex
@@ -9,4 +9,14 @@ defmodule ElixirJobBoard.Factory do
        location: "Somewhere",
        published_at: Ecto.DateTime.utc}
   end
+
+  def user_factory do
+    %ElixirJobBoard.User{
+      email: "some_content@some_content.com",
+      # User password is password the value for the key crypted_paswword
+      # is the hashed value for password
+      crypted_password: "$2b$12$PryIurhZCfAgTXW0Rqz0oOAxJ00WV6OU30cvWsoyGefFNhmDnq6K2",
+      admin: false
+    }
+  end
 end

--- a/lib/elixir_job_board/factory.ex
+++ b/lib/elixir_job_board/factory.ex
@@ -12,7 +12,7 @@ defmodule ElixirJobBoard.Factory do
 
   def user_factory do
     %ElixirJobBoard.User{
-      email: "some_content@some_content.com",
+      email: sequence(:email, &"email-#{&1}@example.com"),
       # User password is password the value for the key crypted_paswword
       # is the hashed value for password
       crypted_password: "$2b$12$PryIurhZCfAgTXW0Rqz0oOAxJ00WV6OU30cvWsoyGefFNhmDnq6K2",

--- a/priv/repo/migrations/20161002025402_add_admin_column.exs
+++ b/priv/repo/migrations/20161002025402_add_admin_column.exs
@@ -1,0 +1,9 @@
+defmodule ElixirJobBoard.Repo.Migrations.AddAdminColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :admin, :boolean, default: false
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -17,17 +17,26 @@ default_password = "password"
 
 pg_changeset = ElixirJobBoard.User.changeset(
   %ElixirJobBoard.User{},
-  %{ "email" => "pg13@pacers.com", "password" => default_password}
+  %{
+    "email" => "pg13@pacers.com",
+    "password" => default_password,
+  }
 )
 myles_changeset = ElixirJobBoard.User.changeset(
   %ElixirJobBoard.User{},
-  %{ "email" => "myles@pacers.com", "password" => default_password }
+  %{
+    "email" => "myles@pacers.com",
+    "password" => default_password
+  }
 )
 zeisloft_changeset = ElixirJobBoard.User.changeset(
   %ElixirJobBoard.User{},
-  %{ "email" => "nick.zeisloft.iu@pacers.com", "password" => default_password }
+  %{
+    "email" => "nick.zeisloft.iu@pacers.com",
+    "password" => default_password
+  }
 )
 
-ElixirJobBoard.Registration.create(pg_changeset, ElixirJobBoard.Repo)
+ElixirJobBoard.Registration.create(Ecto.Changeset.change(pg_changeset, admin: true), ElixirJobBoard.Repo)
 ElixirJobBoard.Registration.create(myles_changeset, ElixirJobBoard.Repo)
 ElixirJobBoard.Registration.create(zeisloft_changeset, ElixirJobBoard.Repo)

--- a/test/controllers/admin/job_controller_test.exs
+++ b/test/controllers/admin/job_controller_test.exs
@@ -1,0 +1,103 @@
+defmodule ElixirJobBoard.JobControllerTest do
+  use ElixirJobBoard.ConnCase
+  alias ElixirJobBoard.Job
+  alias ElixirJobBoard.User
+  import ElixirJobBoard.Factory
+
+  setup do
+    user = ElixirJobBoard.Factory.insert(:user, %{ admin: true })
+    { :ok, user: Repo.get(User, user.id) }
+  end
+
+  test "GET /jobs", %{user: user} do
+    conn = build_conn()
+            |> assign(:current_user, user)
+            |> get("/admin/jobs")
+    assert html_response(conn, 200)
+  end
+
+  test "GET /jobs/new", %{user: user} do
+    conn = build_conn()
+            |> assign(:current_user, user)
+            |> get("/admin/jobs/new")
+    assert html_response(conn, 200)
+  end
+
+  test "GET /jobs/:id", %{user: user} do
+    job = insert(:job)
+    conn = build_conn()
+            |> assign(:current_user, user)
+            |> get("/admin/jobs/#{job.id}")
+    assert html_response(conn, 200)
+  end
+
+  test "GET /jobs/:id/edit", %{user: user} do
+    job = insert(:job)
+    conn = build_conn()
+            |> assign(:current_user, user)
+            |> get("/admin/jobs/#{job.id}/edit")
+    assert html_response(conn, 200)
+  end
+
+  test "successful job /jobs", %{user: user} do
+    jobs_count = length(Repo.all(Job))
+    job_params = %{"title"        => "Something Important",
+                  "description"   => "a new job",
+                  "poster_email"  => "poster.email@example.com",
+                  "contact_email" => "contact.email@example.com",
+                  "location"      => "Somewhere",
+                  "published_at"  => Ecto.DateTime.utc}
+    conn = build_conn()
+            |> assign(:current_user, user)
+            |> post("/admin/jobs", %{"job" => job_params})
+    assert get_flash(conn, :info) == "Job created successfully."
+    assert redirected_to(conn) =~ "/admin/jobs"
+    assert (length(Repo.all(Job))) > jobs_count
+    assert_in_delta(jobs_count, length(Repo.all(Job)), 2)
+  end
+
+  test "unsuccessful job /jobs", %{user: user} do
+    jobs_count = length(Repo.all(Job))
+    job_params = %{"title"        => "Something Important",
+                  "poster_email"  => "poster.email@example.com",
+                  "contact_email" => "contact.email@example.com",
+                  "location"      => "Somewhere",
+                  "published_at"  => Ecto.DateTime.utc}
+    refute Job.changeset(%Job{}, job_params).valid?
+    conn = build_conn()
+            |> assign(:current_user, user)
+            |> post("/admin/jobs", %{"job" => job_params})
+    assert html_response(conn, 200)
+    assert jobs_count == length(Repo.all(Job))
+    assert_in_delta(jobs_count, length(Repo.all(Job)), 1)
+  end
+
+  test "successful PATCH /jobs/:id", %{user: user} do
+    job = insert(:job)
+    job_params = %{"title" => "Something Important"}
+    conn = build_conn()
+            |> assign(:current_user, user)
+            |> patch("/admin/jobs/#{job.id}", %{"id" => job.id, "job" => job_params})
+    assert get_flash(conn, :info) == "Job successfully updated."
+    assert redirected_to(conn) =~ "/admin/jobs/#{job.id}"
+  end
+
+  test "unsuccessful PATCH /jobs/:id", %{user: user} do
+    job = insert(:job)
+    job_params = %{"title" => nil}
+    conn = build_conn()
+            |> assign(:current_user, user)
+            |> patch("/admin/jobs/#{job.id}", %{"id" => job.id, "job" => job_params})
+    assert html_response(conn, 200)
+    refute Job.changeset(job, job_params).valid?
+  end
+
+  test "DELETE /jobs/:id", %{user: user} do
+    job = insert(:job)
+    conn = build_conn()
+            |> assign(:current_user, user)
+            |> delete("/admin/jobs/#{job.id}", %{"id" => job.id})
+    assert get_flash(conn, :info) == "Job successfully deleted."
+    assert redirected_to(conn) =~ "/admin/jobs"
+  end
+end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -15,4 +15,12 @@ defmodule ElixirJobBoard.UserTest do
     changeset = User.changeset(%User{}, @invalid_attrs)
     refute changeset.valid?
   end
+
+  test "is_admin? with admin user" do
+    assert User.is_admin?(%User{ admin: true })
+  end
+
+  test "is_admin? with non admin user" do
+    refute User.is_admin?(%User{ admin: false })
+  end
 end

--- a/test/plugs/authenticate_admin_test.exs
+++ b/test/plugs/authenticate_admin_test.exs
@@ -11,11 +11,8 @@ defmodule ElixirJobBoard.Plugs.AuthenticateAdminTest do
 
   test "user is redirected when current_user is not assigned" do
     conn = build_conn()
-      |> Map.put(:secret_key_base, String.duplicate("abcdefgh", 8))
-      |> Plug.Session.call(@session)
-      |> fetch_session
-      |> fetch_flash
-      |> ElixirJobBoard.Plugs.AuthenticateAdmin.call(%{})
+            |> setup_session
+            |> ElixirJobBoard.Plugs.AuthenticateAdmin.call(%{})
 
     assert redirected_to(conn) == "/"
   end
@@ -23,12 +20,9 @@ defmodule ElixirJobBoard.Plugs.AuthenticateAdminTest do
   test "user is redirected when current_user is assigned but isn't an admin" do
     user = ElixirJobBoard.Factory.insert(:user, %{ admin: false })
     conn = build_conn()
-      |> Map.put(:secret_key_base, String.duplicate("abcdefgh", 8))
-      |> Plug.Session.call(@session)
-      |> fetch_session
-      |> fetch_flash
-      |> put_session(:current_user, user.id)
-      |> ElixirJobBoard.Plugs.AuthenticateAdmin.call(%{})
+            |> setup_session
+            |> put_session(:current_user, user.id)
+            |> ElixirJobBoard.Plugs.AuthenticateAdmin.call(%{})
 
     assert redirected_to(conn) == "/"
   end
@@ -36,13 +30,18 @@ defmodule ElixirJobBoard.Plugs.AuthenticateAdminTest do
   test "user passes through when current_user is assigned and is an admin" do
     user = ElixirJobBoard.Factory.insert(:user, %{ admin: true })
     conn = build_conn()
+            |> setup_session
+            |> put_session(:current_user, user.id)
+            |> ElixirJobBoard.Plugs.AuthenticateAdmin.call(%{})
+
+    assert conn.status != 302
+  end
+
+  defp setup_session(conn) do
+    conn
       |> Map.put(:secret_key_base, String.duplicate("abcdefgh", 8))
       |> Plug.Session.call(@session)
       |> fetch_session
       |> fetch_flash
-      |> put_session(:current_user, user.id)
-      |> ElixirJobBoard.Plugs.AuthenticateAdmin.call(%{})
-
-    assert conn.status != 302
   end
 end

--- a/test/plugs/authenticate_admin_test.exs
+++ b/test/plugs/authenticate_admin_test.exs
@@ -1,0 +1,48 @@
+defmodule ElixirJobBoard.Plugs.AuthenticateAdminTest do
+  use ElixirJobBoard.ConnCase
+
+  @session  Plug.Session.init([
+    store:            :cookie,
+    key:              "_app",
+    encryption_salt:  "secret",
+    signing_salt:     "secret",
+    encrypt:          false
+  ])
+
+  test "user is redirected when current_user is not assigned" do
+    conn = build_conn()
+      |> Map.put(:secret_key_base, String.duplicate("abcdefgh", 8))
+      |> Plug.Session.call(@session)
+      |> fetch_session
+      |> fetch_flash
+      |> ElixirJobBoard.Plugs.AuthenticateAdmin.call(%{})
+
+    assert redirected_to(conn) == "/"
+  end
+
+  test "user is redirected when current_user is assigned but isn't an admin" do
+    user = ElixirJobBoard.Factory.insert(:user, %{ admin: false })
+    conn = build_conn()
+      |> Map.put(:secret_key_base, String.duplicate("abcdefgh", 8))
+      |> Plug.Session.call(@session)
+      |> fetch_session
+      |> fetch_flash
+      |> put_session(:current_user, user.id)
+      |> ElixirJobBoard.Plugs.AuthenticateAdmin.call(%{})
+
+    assert redirected_to(conn) == "/"
+  end
+
+  test "user passes through when current_user is assigned and is an admin" do
+    user = ElixirJobBoard.Factory.insert(:user, %{ admin: true })
+    conn = build_conn()
+      |> Map.put(:secret_key_base, String.duplicate("abcdefgh", 8))
+      |> Plug.Session.call(@session)
+      |> fetch_session
+      |> fetch_flash
+      |> put_session(:current_user, user.id)
+      |> ElixirJobBoard.Plugs.AuthenticateAdmin.call(%{})
+
+    assert conn.status != 302
+  end
+end

--- a/web/controllers/admin/job_controller.ex
+++ b/web/controllers/admin/job_controller.ex
@@ -1,0 +1,56 @@
+defmodule ElixirJobBoard.Admin.JobController do
+  use ElixirJobBoard.Web, :controller
+  require IEx
+
+  alias ElixirJobBoard.Job
+
+  plug ElixirJobBoard.Plugs.AuthenticateAdmin
+
+  def index(conn, _params) do
+    jobs = Repo.all(Job)
+    render conn, "index.html", jobs: jobs
+  end
+
+  def show(conn, %{"id" => id}) do
+    job = Repo.get(Job, id)
+    render conn, "show.html", job: job
+  end
+
+  def new(conn, _params) do
+    changeset = Job.changeset(%Job{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"job" => job_params}) do
+    changeset = Job.changeset(%Job{}, job_params)
+
+    case Repo.insert(changeset) do
+      {:ok, _job} ->
+        conn
+        |> put_flash(:info, "Job created successfully.")
+        |> redirect(to: job_path(conn, :index))
+      {:error, changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def edit(conn, %{"id" => id}) do
+    job = Repo.get(Job, id)
+    changeset = Job.changeset(job)
+    render(conn, "edit.html", job: job, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "job" => job_params}) do
+    job = Repo.get(Job, id)
+    changeset = Job.changeset(job, job_params)
+
+    case Repo.update(changeset) do
+      {:ok, _job} ->
+        conn
+        |> put_flash(:info, "Job successfully updated.")
+        |> redirect(to: job_path(conn, :show, id))
+      {:error, changeset} ->
+        render(conn, "edit.html", id: id, changeset: changeset, job: job)
+    end
+  end
+end

--- a/web/controllers/admin/job_controller.ex
+++ b/web/controllers/admin/job_controller.ex
@@ -4,8 +4,6 @@ defmodule ElixirJobBoard.Admin.JobController do
 
   alias ElixirJobBoard.Job
 
-  plug ElixirJobBoard.Plugs.AuthenticateAdmin
-
   def index(conn, _params) do
     jobs = Repo.all(Job)
     render conn, "index.html", jobs: jobs

--- a/web/controllers/admin/job_controller.ex
+++ b/web/controllers/admin/job_controller.ex
@@ -51,4 +51,16 @@ defmodule ElixirJobBoard.Admin.JobController do
         render(conn, "edit.html", id: id, changeset: changeset, job: job)
     end
   end
+
+  def delete(conn, %{"id" => id}) do
+    job = Repo.get(Job, id)
+    case Repo.delete(job) do
+      {:ok, _job} ->
+        conn
+        |> put_flash(:info, "Job successfully deleted.")
+        |> redirect(to: job_path(conn, :index))
+      {:error, changeset} ->
+        render(conn, "show.html", id: id, job: job)
+    end
+  end
 end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -5,6 +5,7 @@ defmodule ElixirJobBoard.User do
     field :email, :string
     field :crypted_password, :string
     field :password, :string, virtual: true
+    field :admin, :boolean
     timestamps()
   end
 
@@ -19,4 +20,7 @@ defmodule ElixirJobBoard.User do
     |> validate_format(:email, ~r/@/)
     |> validate_length(:password, min: 5)
   end
+
+  def is_admin?(%ElixirJobBoard.User{ admin: true }), do: true
+  def is_admin?(_), do: false
 end

--- a/web/plugs/authenticate_admin.ex
+++ b/web/plugs/authenticate_admin.ex
@@ -1,0 +1,39 @@
+require IEx
+defmodule ElixirJobBoard.Plugs.AuthenticateAdmin do
+  import Plug.Conn
+  import Phoenix.Controller, only: [put_flash: 3, redirect: 2]
+
+  alias ElixirJobBoard.Repo
+  alias ElixirJobBoard.User
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    user = get_user(conn)
+    IEx.pry
+    if user && User.is_admin?(user) do
+      conn |> assign(:current_user, user)
+    else
+      conn
+      |> put_flash(:info, "You must be logged in as an admin.")
+      |> redirect(to: "/")
+      |> halt
+    end
+  end
+
+  defp get_user(conn) do
+    case conn.assigns[:current_user] do
+      nil  -> fetch_user(conn)
+      user -> user
+    end
+  end
+
+  defp fetch_user(conn) do
+    find_user(get_session(conn, :current_user))
+  end
+
+  defp find_user(nil), do: nil
+  defp find_user(id) do
+    Repo.get(User, id)
+  end
+end

--- a/web/plugs/authenticate_admin.ex
+++ b/web/plugs/authenticate_admin.ex
@@ -1,4 +1,3 @@
-require IEx
 defmodule ElixirJobBoard.Plugs.AuthenticateAdmin do
   import Plug.Conn
   import Phoenix.Controller, only: [put_flash: 3, redirect: 2]
@@ -10,7 +9,6 @@ defmodule ElixirJobBoard.Plugs.AuthenticateAdmin do
 
   def call(conn, _opts) do
     user = get_user(conn)
-    IEx.pry
     if user && User.is_admin?(user) do
       conn |> assign(:current_user, user)
     else

--- a/web/router.ex
+++ b/web/router.ex
@@ -26,7 +26,7 @@ defmodule ElixirJobBoard.Router do
   end
 
   scope "/admin", ElixirJobBoard do
-    pipe_through :browser # Use the default browser stack
+    pipe_through [:browser, ElixirJobBoard.Plugs.AuthenticateAdmin]
 
     resources "/jobs", Admin.JobController
   end

--- a/web/router.ex
+++ b/web/router.ex
@@ -25,6 +25,12 @@ defmodule ElixirJobBoard.Router do
     resources "/posts", PostsController
   end
 
+  scope "/admin", ElixirJobBoard do
+    pipe_through :browser # Use the default browser stack
+
+    resources "/jobs", Admin.JobController
+  end
+
   # Other scopes may use custom stacks.
   # scope "/api", ElixirJobBoard do
   #   pipe_through :api

--- a/web/templates/admin/job/edit.html.eex
+++ b/web/templates/admin/job/edit.html.eex
@@ -1,0 +1,6 @@
+<h2>Edit post</h2>
+
+<%= render "form.html", changeset: @changeset,
+                        action: job_path(@conn, :update, @job) %>
+
+<%= link "Back", to: job_path(@conn, :index) %>

--- a/web/templates/admin/job/form.html.eex
+++ b/web/templates/admin/job/form.html.eex
@@ -36,6 +36,12 @@
   </div>
 
   <div class="form-group">
+    <%= label f, :published_at, class: "control-label" %>
+    <%= datetime_select f, :published_at, class: "form-control" %>
+    <%= error_tag f, :published_at %>
+  </div>
+
+  <div class="form-group">
     <%= submit "Submit", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/web/templates/admin/job/index.html.eex
+++ b/web/templates/admin/job/index.html.eex
@@ -5,6 +5,7 @@
     <tr>
       <td><%= Phoenix.HTML.Link.link("#{job.title}", to: "/admin/jobs/#{job.id}") %></td>
       <td><%= Phoenix.HTML.Link.link("Edit", to: "/admin/jobs/#{job.id}/edit") %></td>
+      <td><%= Phoenix.HTML.Link.link("Delete", to: "/admin/jobs/#{job.id}", method: :delete) %></td>
     </tr>
   <%= end %>
 </div>

--- a/web/templates/admin/job/index.html.eex
+++ b/web/templates/admin/job/index.html.eex
@@ -1,0 +1,10 @@
+<div class="jumbotron">
+  <h2>Job Posts</h2>
+  <table class="table table-striped">
+  <%= for job <- @jobs do %>
+    <tr>
+      <td><%= Phoenix.HTML.Link.link("#{job.title}", to: "/admin/jobs/#{job.id}") %></td>
+      <td><%= Phoenix.HTML.Link.link("Edit", to: "/admin/jobs/#{job.id}/edit") %></td>
+    </tr>
+  <%= end %>
+</div>

--- a/web/templates/admin/job/new.html.eex
+++ b/web/templates/admin/job/new.html.eex
@@ -1,0 +1,6 @@
+<h2>New job</h2>
+
+<%= render "form.html", changeset: @changeset,
+                        action: job_path(@conn, :create) %>
+
+<%= link "Back", to: job_path(@conn, :index) %>

--- a/web/templates/admin/job/show.html.eex
+++ b/web/templates/admin/job/show.html.eex
@@ -1,0 +1,3 @@
+<div class="jumbotron">
+  <h2>Title: <%= @job.title %></h2>
+</div>

--- a/web/views/admin/job_view.ex
+++ b/web/views/admin/job_view.ex
@@ -1,0 +1,3 @@
+defmodule ElixirJobBoard.Admin.JobView do
+  use ElixirJobBoard.Web, :view
+end


### PR DESCRIPTION
I have some work to do here, yet, but I wanted to get this out there so it was clear what is being worked on. 

This creates an admin section, `/admin/jobs` and the related endpoints. I've not actually done anything with delete yet. Nor have I written tests for the plug I created, or the admin controllers, etc. 
